### PR TITLE
Updated module description that includes the default behavior first

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
 	"name": "award-xp",
 	"title": "Award XP",
-	"description": "Award Experience to the group, which will be devided between the players and automatically added their character sheets.",
+	"description": "Award Experience to the group, the value of which will awarded to each player, or divided evenly between the players and automatically update their character sheets.",
 	"version": "1.5.0",
 	"minimumCoreVersion" : "9.238",
 	"compatibleCoreVersion" : "9",


### PR DESCRIPTION
Current default behavior is to award entered XP to EACH player, whereas the module description says that the entered XP will be split evenly. This should help reduce confusion when the module is used for the first time.