### PR TITLE
Fixes v11 compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
 	"version": "1.5.1",
 	"compatibility": {
 		"minimum": "9",
-		"compatibleCoreVersion": "11"
+		"verified": "11"
 	},
 	"authors": [
 		{


### PR DESCRIPTION
https://foundryvtt.com/article/manifest-migration-guide/

Manifest changes occurred in v10, fixing this so that the error no longer appears in v11.